### PR TITLE
Add #code and #symbol methods to Spotify::Error

### DIFF
--- a/lib/spotify/error.rb
+++ b/lib/spotify/error.rb
@@ -50,11 +50,15 @@ module Spotify
         end
       end
     end
+    
+    attr_reader :code, :symbol
 
     # Overridden to allow raising errors with just an error code.
     #
     # @param [Integer, String] code_or_message spotify error code, or string message.
     def initialize(code_or_message = nil)
+      @code, @symbol = self.class.disambiguate(code_or_message)
+      
       if code_or_message.is_a?(Integer) or code_or_message.is_a?(Symbol)
         code_or_message &&= self.class.explain(code_or_message)
       end


### PR DESCRIPTION
Hey,

I thought that it would be great if I could just get symbol of the spotify error like `Spotify::Error.new(:ok).code` and `Spotify::Error.new(:ok).symbol`, instead of toying with RegExping the error's message.
